### PR TITLE
fix: allow to run checkstyle parser with not tested version

### DIFF
--- a/src/parse/checkstyle_parser.test.ts
+++ b/src/parse/checkstyle_parser.test.ts
@@ -122,21 +122,29 @@ describe("parseCheckstyle()", () => {
     expect(violations).toHaveLength(4)
   })
 
-  it("throws up for unknown checkstyle version", () => {
+  it("log warn for untested checkstyle version", () => {
     const root = "/root/"
+    const untestedVersion = "7.0"
     const checkstyle = {
       declaration: { attributes: { version: "1.0", encoding: "utf-8" } },
       elements: [
         {
           type: "element",
           name: "checkstyle",
-          attributes: { version: "7.0" },
+          attributes: { version: untestedVersion },
           elements: [],
         },
       ],
     }
+    const spiedConsole = jest.spyOn(global.console, "warn")
 
-    expect(() => parseCheckstyle(checkstyle, root)).toThrow()
+    parseCheckstyle(checkstyle, root)
+
+    expect(spiedConsole).toBeCalled()
+    const warnLog = spiedConsole.mock.calls[0][0]
+    expect(warnLog).toContain(untestedVersion)
+
+    spiedConsole.mockRestore()
   })
 
   it("parses checkstyle 8.0 without any violations", () => {

--- a/src/parse/checkstyle_parser.ts
+++ b/src/parse/checkstyle_parser.ts
@@ -15,8 +15,10 @@ export function parseCheckstyle(report: any, root: string): Violation[] {
         case "8.0":
         case "4.3":
           return parseCheckstyle8_0(report, root)
-        default:
-          throw new Error(`Checkstyle version ${rootVersion} is not supported.`)
+        default: {
+          console.warn(`Compatibility with version ${rootVersion} not tested`)
+          return parseCheckstyle8_0(report, root)
+        }
       }
     case "issues":
       const rootFormat = report.elements[0].attributes.format


### PR DESCRIPTION
Hey, thank you for effort of keeping this project!
I want to use this plugin to report lint problems for the project that using usual Checkstyle, therefore in the XML I have following version: `version="8.40"` and I can't use this plugin to do reports.

I think Checkstyle format should be quite stable as it used by many tools though seems they don't have XSD for this (https://github.com/checkstyle/checkstyle/issues/5166), so we can try to parse with warning?