### PR TITLE
ci: yarn publish GitHub workflow setup

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,19 @@
+name: Lint
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+jobs:
+  pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v3.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+name: Publish
+on:
+  release:
+    types: [published]
+jobs:
+  yarn:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          registry-url: 'https://registry.npmjs.org'
+          
+      - name: Set version
+        run: yarn version --new-version "${{ github.event.release.tag_name }}" --no-git-tag-version
+
+      - name: Publish
+        run: yarn publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,7 @@ jobs:
           tag_name: ${{ steps.changelog.outputs.tag }}
           release_name: ${{ steps.changelog.outputs.tag }}
           body: ${{ steps.changelog.outputs.tag }}
+          fallback-version: '1.0.0'
 
       - name: Update package
         if: ${{ steps.changelog.outputs.skipped == 'false' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,19 +1,53 @@
 name: Publish
-on:
-  release:
-    types: [published]
+
+on: workflow_dispatch
+
 jobs:
-  yarn:
+  publish-npm:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
           node-version: 12
           registry-url: 'https://registry.npmjs.org'
-          
-      - name: Set version
-        run: yarn version --new-version "${{ github.event.release.tag_name }}" --no-git-tag-version
+
+      - name: Configure CI Git User
+        run: |
+          git config user.name "github-actions";
+          git config user.email "github-actions@github.com";
+
+      - name: Conventional Changelog Action
+        id: changelog
+        uses: TriPSs/conventional-changelog-action@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          git-user-name: "github-actions"
+          git-user-email: "github-actions@github.com"
+          tag-prefix: ''
+          output-file: 'CHANGELOG.md'
+
+      - name: Create Release
+        uses: actions/create-release@v1
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.changelog.outputs.tag }}
+          release_name: ${{ steps.changelog.outputs.tag }}
+          body: ${{ steps.changelog.outputs.tag }}
+
+      - name: Update package
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+        run: |
+          npm i --package-lock-only
+          git add .
+          git commit --amend -m "ci(release): ${{ steps.changelog.outputs.tag }}"
+          git push -f
+        env:
+          GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish
         run: yarn publish --access public


### PR DESCRIPTION
Adds a workflow with a release-trigger that updates the package version depending on the tag name and publishes the package.