### PR TITLE
feat: Determine root folder at runtime to properly sanitize absolute paths

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -63,9 +63,14 @@ const mockFileSync = jest.fn(
 
 </issues>`,
 )
+
+const mockFiles: string[] = []
+const mockFileExistsSync = (path: string) => mockFiles.includes(path)
+
 jest.mock("glob", () => (_, cb) => cb(null, mockGlob()))
 jest.mock("fs", () => ({
-  readFileSync: (path) => mockFileSync(path),
+  readFileSync: (path: string) => mockFileSync(path),
+  existsSync: (path: string) => mockFileExistsSync(path),
 }))
 
 declare global {
@@ -177,6 +182,25 @@ describe("scanXmlReport()", () => {
     const messageCallback = jest.fn()
 
     await scanXmlReport(git, xmlReport, root, false, messageCallback)
+
+    const msg = "Hardcoded text"
+    const file = "feature/src/main/res/layout/fragment_password_reset.xml"
+    const line = 13
+    const severity = "Warning"
+    expect(messageCallback).toBeCalledWith(msg, file, line, severity)
+  })
+
+  it("returns correct file location when root is different", async () => {
+    const git = {
+      modified_files: ["feature/src/main/res/layout/fragment_password_reset.xml"],
+      created_files: [],
+    }
+
+    mockFiles.push("/otherRoot/feature/src/main/res/layout/fragment_password_reset_2.xml")
+
+    const messageCallback = jest.fn()
+
+    await scanXmlReport(git, xmlReport, "/otherRoot/", false, messageCallback)
 
     const msg = "Hardcoded text"
     const file = "feature/src/main/res/layout/fragment_password_reset.xml"

--- a/src/parse/checkstyle_parser.test.ts
+++ b/src/parse/checkstyle_parser.test.ts
@@ -1,5 +1,11 @@
 import { parseCheckstyle } from "./checkstyle_parser"
 
+const mockFiles: string[] = []
+
+jest.mock("fs", () => ({
+  existsSync: (path) => mockFiles.includes(path),
+}))
+
 describe("parseCheckstyle()", () => {
   it("maps checkstyle 8.0 violations properly", () => {
     const root = "/root/"

--- a/src/parse/checkstyle_parser.ts
+++ b/src/parse/checkstyle_parser.ts
@@ -41,7 +41,7 @@ function parseAndroidLint(report: any, root: string): Violation[] {
     return []
   }
 
-  report.elements[0].elements.forEach(issueElement => {
+  report.elements[0].elements.forEach((issueElement) => {
     if (issueElement.name !== "issue") {
       console.log(`Illegal element: ${issueElement.name}, expected issue. Ignoring.`)
     } else {
@@ -56,7 +56,7 @@ function parseAndroidLint(report: any, root: string): Violation[] {
       const errorLine1 = attributes.errorLine1
       const errorLine2 = attributes.errorLine2
 
-      issueElement.elements.forEach(fileElement => {
+      issueElement.elements.forEach((fileElement) => {
         if (fileElement.name !== "location") {
           console.warn(`Illegal element ${fileElement.name}, expected location. Ignoring.`)
         } else {
@@ -81,6 +81,20 @@ function parseAndroidLint(report: any, root: string): Violation[] {
 }
 
 /**
+ * Finds the filename of the first violation as specified in the report.
+ * @param report
+ * @returns filename as a `string` or `undefined` if it could not be found
+ */
+export function findFirstViolationFilename(report: any): string | undefined {
+  try {
+    const fileElement = report.elements[0].elements[0]
+    return fileElement.attributes.name ?? fileElement.elements[0].attributes.file
+  } catch (d) {
+    return undefined
+  }
+}
+
+/**
  *
  * @param report Checktyle report as JavaScript object
  * @param root Project root path
@@ -92,10 +106,10 @@ function parseCheckstyle8_0(report: any, root: string): Violation[] {
     return []
   }
 
-  report.elements[0].elements.forEach(fileElement => {
+  report.elements[0].elements.forEach((fileElement) => {
     const fileName = fileElement.attributes.name.replace(root, "").replace(/^\/+/, "")
 
-    fileElement.elements.forEach(errorElement => {
+    fileElement.elements.forEach((errorElement) => {
       const attributes = errorElement.attributes
       const line = +attributes.line
       const column = +attributes.column


### PR DESCRIPTION
Currently lint files absolute paths are sanitized by removing the current folder from there. It is
however possible that the current folder does not match the folder in the lint file. For instance,
if the lint file was generated ni a different machine than where danger is running. This is common
when using dockerized instances and performing lint in one stage and danger in a follow-up one.