### PR TITLE
fix: support lint files calculated in a different machine/process

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -64,7 +64,6 @@ const mockFileSync = jest.fn(
 </issues>`,
 )
 
-const mockFiles: string[] = []
 const mockFileExistsSync = jest.fn()
 
 jest.mock("glob", () => (_, cb) => cb(null, mockGlob()))

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -65,7 +65,7 @@ const mockFileSync = jest.fn(
 )
 
 const mockFiles: string[] = []
-const mockFileExistsSync = (path: string) => mockFiles.includes(path)
+const mockFileExistsSync = jest.fn()
 
 jest.mock("glob", () => (_, cb) => cb(null, mockGlob()))
 jest.mock("fs", () => ({
@@ -195,8 +195,9 @@ describe("scanXmlReport()", () => {
       modified_files: ["feature/src/main/res/layout/fragment_password_reset.xml"],
       created_files: [],
     }
-
-    mockFiles.push("/otherRoot/feature/src/main/res/layout/fragment_password_reset.xml")
+    mockFileExistsSync.mockImplementation((path) =>
+      ["/otherRoot/feature/src/main/res/layout/fragment_password_reset.xml"].includes(path),
+    )
 
     const messageCallback = jest.fn()
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -63,9 +63,14 @@ const mockFileSync = jest.fn(
 
 </issues>`,
 )
+
+const mockFiles: string[] = []
+const mockFileExistsSync = (path: string) => mockFiles.includes(path)
+
 jest.mock("glob", () => (_, cb) => cb(null, mockGlob()))
 jest.mock("fs", () => ({
-  readFileSync: (path) => mockFileSync(path),
+  readFileSync: (path: string) => mockFileSync(path),
+  existsSync: (path: string) => mockFileExistsSync(path),
 }))
 
 declare global {
@@ -177,6 +182,25 @@ describe("scanXmlReport()", () => {
     const messageCallback = jest.fn()
 
     await scanXmlReport(git, xmlReport, root, false, messageCallback)
+
+    const msg = "Hardcoded text"
+    const file = "feature/src/main/res/layout/fragment_password_reset.xml"
+    const line = 13
+    const severity = "Warning"
+    expect(messageCallback).toBeCalledWith(msg, file, line, severity)
+  })
+
+  it("returns correct file location when root is different", async () => {
+    const git = {
+      modified_files: ["feature/src/main/res/layout/fragment_password_reset.xml"],
+      created_files: [],
+    }
+
+    mockFiles.push("/otherRoot/feature/src/main/res/layout/fragment_password_reset.xml")
+
+    const messageCallback = jest.fn()
+
+    await scanXmlReport(git, xmlReport, "/otherRoot/", false, messageCallback)
 
     const msg = "Hardcoded text"
     const file = "feature/src/main/res/layout/fragment_password_reset.xml"

--- a/src/parse/checkstyle_parser.test.ts
+++ b/src/parse/checkstyle_parser.test.ts
@@ -1,5 +1,11 @@
 import { parseCheckstyle } from "./checkstyle_parser"
 
+const mockFiles: string[] = []
+
+jest.mock("fs", () => ({
+  existsSync: (path) => mockFiles.includes(path),
+}))
+
 describe("parseCheckstyle()", () => {
   it("maps checkstyle 8.0 violations properly", () => {
     const root = "/root/"


### PR DESCRIPTION
When building in CI it is common that a task is generating the lint file, while a different task
runs dagger. These tasks don't need to run in the same machine. The current code assumes so when
sanitizing absolute paths by replacing the root (pwd) with "". This does not work if the root is
different.

fix #29