### PR TITLE
fix: fix file path logic for files with the same name and different path

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -204,7 +204,10 @@ describe("scanXmlReport()", () => {
       created_files: [],
     }
     mockFileExistsSync.mockImplementation((path) =>
-      ["/otherRoot/feature/src/main/res/layout/fragment_password_reset.xml"].includes(path),
+      [
+        "/otherRoot/feature/src/main/res/layout/fragment_password_reset.xml",
+        "/otherRoot/fragment_password_reset.xml",
+      ].includes(path),
     )
 
     const messageCallback = jest.fn()

--- a/src/parse/checkstyle_parser.ts
+++ b/src/parse/checkstyle_parser.ts
@@ -90,7 +90,7 @@ function parseAndroidLint(report: any, root: string): Violation[] {
 function calculateRelativeFileName(file: string, root: string) {
   const components = file.split(path.sep)
   for (let i = 1; i < components.length; i++) {
-    const suffixComponents = components.slice(-i)
+    const suffixComponents = components.slice(i)
     const candidateFile = path.resolve(root, ...suffixComponents)
     if (fs.existsSync(candidateFile)) {
       return path.relative(root, candidateFile)


### PR DESCRIPTION
[554e0](https://github.com/damian-burke/danger-plugin-lint-report/commit/554e0042b39065d76fe61ea96e6e19f7c879fdca) added support for dynamically calculating the file paths (as the previous implementation assumed the root was the same in lint files and when we execute this plugin).

The logic is currently failing when we have 2 files with the same name in different paths. For instance:

- **Lint location file:** `/lintRoot/folderA/build.gradle` (and `lintRoot/build.gradle` also exists)
- **Root:** `/dangerRoot`
- **Resolved file:** `/dangerRoot/build.gradle` (it should have been `lintRoot/folderA/build.gradle`

