### PR TITLE
feat: add custom ViolationFormatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ interface CheckstyleConfig {
    * This can be useful if there are multiple reports being parsed to make them distinguishable.
    */
   outputPrefix?: string
+  
+  /**
+   * Optional: Override the violation formatter to customize the output message.
+   */
+   violationFormatter?: ViolationFormatter
 }
 ```
 ## Changelog

--- a/src/checkstyleconfig.ts
+++ b/src/checkstyleconfig.ts
@@ -20,4 +20,9 @@ interface CheckstyleConfig {
    * This can be useful if there are multiple reports being parsed to make them distinguishable.
    */
   outputPrefix?: string
+
+  /**
+   * Optional: Override the violation formatter to customize the output message.
+   */
+   violationFormatter?: ViolationFormatter
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,40 +1,62 @@
 import { maxParallel, scan, scanXmlReport } from "."
 
 const root = "/root/"
+const expectedAndroidLintViolation1: Violation = {
+  issueId: "HardcodedText",
+  category: "Internationalization",
+  explanation: "Hardcoding text attributes directly in layout files is bad.",
+  summary: "Hardcoded text",
+  file: "feature/src/main/res/layout/fragment_password_reset.xml",
+  line: 13,
+  column: 9,
+  severity: "Warning",
+  message: "Hardcoded string Email Address, should use `@string` resource",
+}
+const expectedAndroidLintViolation2: Violation = {
+  issueId: "HardcodedNumber",
+  category: "Maintenance",
+  explanation: "Hardcoding numbers directly in layout files is bad.",
+  summary: "Hardcoded numbers",
+  file: "feature/src/main/res/layout/fragment_password_reset_2.xml",
+  line: 14,
+  column: 10,
+  severity: "Warning",
+  message: "Hardcoded number 123.",
+}
 const xmlReport = `
 <?xml version="1.0" encoding="UTF-8"?>
 <issues format="5" by="lint 4.2.0-alpha01">
 
     <issue
-        id="HardcodedText"
-        severity="Warning"
-        message="Hardcoded string &quot;Password&quot;, should use \`@string\` resource"
-        category="Internationalization"
+        id="${expectedAndroidLintViolation1.issueId}"
+        severity="${expectedAndroidLintViolation1.severity}"
+        message="${expectedAndroidLintViolation1.message}"
+        category="${expectedAndroidLintViolation1.category}"
         priority="5"
-        summary="Hardcoded text"
-        explanation="Hardcoding text attributes directly in layout files is bad for several reasons:&#xA;&#xA;* When creating configuration variations (for example for landscape or portrait) you have to repeat the actual text (and keep it up to date when making changes)&#xA;&#xA;* The application cannot be translated to other languages by just adding new translations for existing string resources.&#xA;&#xA;There are quickfixes to automatically extract this hardcoded string into a resource lookup."
+        summary="${expectedAndroidLintViolation1.summary}"
+        explanation="${expectedAndroidLintViolation1.explanation}"
         errorLine1="        android:hint=&quot;Password&quot;"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-        file="/root/feature/src/main/res/layout/fragment_password_reset_2.xml"
-            line="25"
-            column="9"/>
+            file="${expectedAndroidLintViolation1.file}"
+            line="${expectedAndroidLintViolation1.line}"
+            column="${expectedAndroidLintViolation1.column}"/>
     </issue>
 
     <issue
-        id="HardcodedText"
-        severity="Warning"
-        message="Hardcoded string &quot;Email Address&quot;, should use \`@string\` resource"
-        category="Internationalization"
+        id="${expectedAndroidLintViolation2.issueId}"
+        severity="${expectedAndroidLintViolation2.severity}"
+        message="${expectedAndroidLintViolation2.message}"
+        category="${expectedAndroidLintViolation2.category}"
         priority="5"
-        summary="Hardcoded text"
-        explanation="Hardcoding text attributes directly in layout files is bad for several reasons:&#xA;&#xA;* When creating configuration variations (for example for landscape or portrait) you have to repeat the actual text (and keep it up to date when making changes)&#xA;&#xA;* The application cannot be translated to other languages by just adding new translations for existing string resources.&#xA;&#xA;There are quickfixes to automatically extract this hardcoded string into a resource lookup."
+        summary="${expectedAndroidLintViolation2.summary}"
+        explanation="${expectedAndroidLintViolation2.explanation}"
         errorLine1="        android:hint=&quot;Email Address&quot;"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="/root/feature/src/main/res/layout/fragment_password_reset.xml"
-            line="13"
-            column="9"/>
+            file="${expectedAndroidLintViolation2.file}"
+            line="${expectedAndroidLintViolation2.line}"
+            column="${expectedAndroidLintViolation2.column}"/>
     </issue>
 
 </issues>
@@ -55,19 +77,19 @@ const mockFileSync = jest.fn(
 <issues format="5" by="lint 4.2.0-alpha01">
 
     <issue
-        id="HardcodedText"
-        severity="Warning"
-        message="Hardcoded string &quot;Email Address&quot;, should use \`@string\` resource"
-        category="Internationalization"
+        id="${expectedAndroidLintViolation1.issueId}"
+        severity="${expectedAndroidLintViolation1.severity}"
+        message="${expectedAndroidLintViolation1.message}"
+        category="${expectedAndroidLintViolation1.category}"
         priority="5"
-        summary="Hardcoded text"
-        explanation="Hardcoding text attributes directly in layout files is bad for several reasons:&#xA;&#xA;* When creating configuration variations (for example for landscape or portrait) you have to repeat the actual text (and keep it up to date when making changes)&#xA;&#xA;* The application cannot be translated to other languages by just adding new translations for existing string resources.&#xA;&#xA;There are quickfixes to automatically extract this hardcoded string into a resource lookup."
+        summary="${expectedAndroidLintViolation1.summary}"
+        explanation="${expectedAndroidLintViolation1.explanation}"
         errorLine1="        android:hint=&quot;Email Address&quot;"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="feature/src/main/res/layout/fragment_password_reset.xml"
-            line="13"
-            column="9"/>
+            file="${expectedAndroidLintViolation1.file}"
+            line="${expectedAndroidLintViolation1.line}"
+            column="${expectedAndroidLintViolation1.column}"/>
     </issue>
 
 </issues>`,
@@ -93,7 +115,7 @@ declare global {
 describe("scan()", () => {
   it("scans multiple files and exits after all are finished", async () => {
     const git = {
-      modified_files: ["feature/src/main/res/layout/fragment_password_reset.xml"],
+      modified_files: [expectedAndroidLintViolation1.file],
       created_files: [],
       structuredDiffForFile: async () =>
         new Promise((res) => setTimeout(() => res({ chunks: [{ changes: [{ type: "add", ln: 13 }] }] }), 100)),
@@ -101,7 +123,7 @@ describe("scan()", () => {
     global.danger = { git }
     global.warn = jest.fn()
 
-    mockGlob.mockImplementation(() => ["feature/src/main/res/layout/fragment_password_reset.xml"])
+    mockGlob.mockImplementation(() => [expectedAndroidLintViolation1.file])
 
     await scan({
       fileMask: "",
@@ -111,6 +133,38 @@ describe("scan()", () => {
 
     expect(global.warn).toHaveBeenCalled()
   })
+
+  it("uses ViolationFormatter to map Violation to string", async () => {
+    let formatFn = jest.fn(violation => {
+      return violation.message;
+    })
+    let violationFormatter: ViolationFormatter = {
+      format: formatFn, 
+    }
+
+    
+    const git = {
+      modified_files: [expectedAndroidLintViolation1.file],
+      created_files: [],
+      structuredDiffForFile: async () =>
+        new Promise((res) => setTimeout(() => res({ chunks: [{ changes: [{ type: "add", ln: expectedAndroidLintViolation1.line }] }] }), 100)),
+    }
+    global.danger = { git }
+    global.warn = jest.fn()
+
+    mockGlob.mockImplementation(() => [expectedAndroidLintViolation1.file])
+
+    await scan({
+      fileMask: "",
+      reportSeverity: true,
+      requireLineModification: true,
+      violationFormatter: violationFormatter,
+    })
+    
+    expect(formatFn).toBeCalledWith(expectedAndroidLintViolation1)
+    expect(global.warn).toBeCalledWith(formatFn(expectedAndroidLintViolation1), expectedAndroidLintViolation1.file, expectedAndroidLintViolation1.line)
+  })
+
 
   it(`scans maximum ${maxParallel} files in parallel to prevent OoM exceptions`, async () => {
     const git = {
@@ -168,57 +222,50 @@ describe("scanXmlReport()", () => {
   it("works across multiple files with require line modification turned off", async () => {
     const git = {
       modified_files: [
-        "feature/src/main/res/layout/fragment_password_reset.xml",
-        "feature/src/main/res/layout/fragment_password_reset_2.xml",
+        expectedAndroidLintViolation1.file,
+        expectedAndroidLintViolation2.file,
       ],
       created_files: [],
     }
 
-    const messageCallback = jest.fn()
+    const violationCallback = jest.fn()
 
-    await scanXmlReport(git, xmlReport, root, false, messageCallback)
+    await scanXmlReport(git, xmlReport, root, false, violationCallback)
 
-    expect(messageCallback).toHaveBeenCalledTimes(2)
+    expect(violationCallback).toHaveBeenCalledTimes(2)
   })
 
   it("returns correct violation data and file path with line modification turned off", async () => {
     const git = {
-      modified_files: ["feature/src/main/res/layout/fragment_password_reset.xml"],
+      modified_files: [expectedAndroidLintViolation1.file],
       created_files: [],
     }
 
-    const messageCallback = jest.fn()
+    const violationCallback = jest.fn()
 
-    await scanXmlReport(git, xmlReport, root, false, messageCallback)
+    await scanXmlReport(git, xmlReport, root, false, violationCallback)
 
-    const msg = "Hardcoded text"
-    const file = "feature/src/main/res/layout/fragment_password_reset.xml"
-    const line = 13
-    const severity = "Warning"
-    expect(messageCallback).toBeCalledWith(msg, file, line, severity)
+    expect(violationCallback).toBeCalledWith(expectedAndroidLintViolation1)
+    expect(violationCallback).toBeCalledWith(expectedAndroidLintViolation2)
   })
 
   it("returns correct file location when root is different", async () => {
     const git = {
-      modified_files: ["feature/src/main/res/layout/fragment_password_reset.xml"],
+      modified_files: [expectedAndroidLintViolation1.file],
       created_files: [],
     }
     mockFileExistsSync.mockImplementation((path) =>
       [
-        "/otherRoot/feature/src/main/res/layout/fragment_password_reset.xml",
-        "/otherRoot/fragment_password_reset.xml",
+        "/otherRoot/" + expectedAndroidLintViolation1,
+        expectedAndroidLintViolation1.file.substring(expectedAndroidLintViolation1.file.indexOf("/", 1)),
       ].includes(path),
     )
 
-    const messageCallback = jest.fn()
+    const violationCallback = jest.fn()
 
-    await scanXmlReport(git, xmlReport, "/otherRoot/", false, messageCallback)
+    await scanXmlReport(git, xmlReport, "/otherRoot/", false, violationCallback)
 
-    const msg = "Hardcoded text"
-    const file = "feature/src/main/res/layout/fragment_password_reset.xml"
-    const line = 13
-    const severity = "Warning"
-    expect(messageCallback).toBeCalledWith(msg, file, line, severity)
+    expect(violationCallback).toBeCalledWith(expectedAndroidLintViolation1)
   })
 
   it("returns correct violation data for checkstyle report with files without messages", async () => {
@@ -234,8 +281,16 @@ describe("scanXmlReport()", () => {
     const msg = "'CircularProgress' is defined but never used. (@typescript-eslint/no-unused-vars)"
     const file = "src/components/ComponentWithError.tsx"
     const line = 2
+    const column = 21
     const severity = "warning"
+    const expectedViolation = {
+      file: file,
+      line: line,
+      column: column,
+      severity: severity,
+      message: msg,
+    }
     expect(messageCallback).toBeCalledTimes(1)
-    expect(messageCallback).toBeCalledWith(msg, file, line, severity)
+    expect(messageCallback).toBeCalledWith(expectedViolation)
   })
 })

--- a/src/parse/checkstyle.ts
+++ b/src/parse/checkstyle.ts
@@ -18,7 +18,7 @@ export async function scanReport(
   report: any,
   root: string,
   requireLineModification: boolean,
-  messageCallback: (msg: MarkdownString, fileName: string, line: number, severity: string) => void,
+  violationCallback: (violation: Violation) => void,
 ) {
   const violations = parseCheckstyle(report, root)
   const files: string[] = []
@@ -45,5 +45,5 @@ export async function scanReport(
     })
   }
 
-  reportViolationsForLines(violations, fileDiffs, requireLineModification, messageCallback)
+  reportViolationsForLines(violations, fileDiffs, requireLineModification, violationCallback)
 }

--- a/src/parse/checkstyle_parser.ts
+++ b/src/parse/checkstyle_parser.ts
@@ -68,10 +68,14 @@ function parseAndroidLint(report: any, root: string): Violation[] {
 
           violations.push({
             file: fileName,
-            line,
-            column,
-            severity,
-            message: summary,
+            line: line,
+            column: column,
+            severity: severity,
+            summary: summary,
+            category: category,
+            message: message,
+            explanation: explanation,
+            issueId: issueId,
           })
         }
       })
@@ -123,9 +127,9 @@ function parseCheckstyle8_0(report: any, root: string): Violation[] {
 
       violations.push({
         file: fileName,
-        line,
-        column,
-        severity,
+        line: line,
+        column: column,
+        severity: severity,
         message: msg,
       })
     })

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -4,7 +4,7 @@ export function reportViolationsForLines(
   violations: Violation[],
   fileDiffs: FileDiff[],
   requireLineModification: boolean,
-  messageCallback: (msg: MarkdownString, fileName: string, line: number, severity: string) => void,
+  violationCallback: (violation: Violation) => void,
 ) {
   // we got all changed lines in fileDiffs (file => list of line)
   violations.forEach(violation => {
@@ -15,7 +15,7 @@ export function reportViolationsForLines(
 
     if (diff) {
       if (!requireLineModification || diff.added_lines.includes(line)) {
-        messageCallback(violation.message, violation.file, violation.line, violation.severity)
+        violationCallback(violation)
       }
     }
   })

--- a/src/violation.ts
+++ b/src/violation.ts
@@ -11,4 +11,10 @@ interface Violation {
    */
   severity: string
   message: string
+
+  // The following attributes are optional, i.e. they may not be present in all scans.
+  category?: string
+  summary?: string
+  explanation?: string
+  issueId?: string
 }

--- a/src/violation_formatter.ts
+++ b/src/violation_formatter.ts
@@ -1,0 +1,3 @@
+interface ViolationFormatter {
+    format: (violation: Violation) => string;
+}


### PR DESCRIPTION
Adds a new optional field to `CheckstyleConfig`:

```ts
  /**
   * Optional: Override the violation reporter to customize the output message.
   */
   violationFormatter?: ViolationFormatter
```

```ts
interface ViolationFormatter{
    report: (violation: Violation) => string;
}
```

If set, the passed instance will be used to format the `Violation` instance to a `string` which will be passed on to the reporting system. If passed, the `outputPrefix` will be applied **after** formatting the `Violation` with the `ViolationFormatter` instance.

Also extends `Violation` with some optional fields for parsed formats that contain more information:

```ts
interface Violation {
  file: string
  line: number
  column: number
  /**
   * Possible severity values:
   * - info
   * - warning
   * - error
   * - fatal
   */
  severity: string
  message: string

  // The following attributes are optional, i.e. they may not be present in all scans.
  category?: string
  summary?: string
  explanation?: string
  issueId?: string
}
```