### PR TITLE
feat: allow to specify project root path

### DIFF
--- a/src/checkstyleconfig.ts
+++ b/src/checkstyleconfig.ts
@@ -24,5 +24,10 @@ interface CheckstyleConfig {
   /**
    * Optional: Override the violation formatter to customize the output message.
    */
-   violationFormatter?: ViolationFormatter
+  violationFormatter?: ViolationFormatter
+
+  /**
+   * Optional: Sets the root directory of the project. Defaults to the current working directory.
+   */
+  projectRoot?: string
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -129,6 +129,7 @@ describe("scan()", () => {
       fileMask: "",
       reportSeverity: true,
       requireLineModification: true,
+      projectRoot: root,
     })
 
     expect(global.warn).toHaveBeenCalled()
@@ -158,6 +159,7 @@ describe("scan()", () => {
       fileMask: "",
       reportSeverity: true,
       requireLineModification: true,
+      projectRoot: root,
       violationFormatter: violationFormatter,
     })
 
@@ -199,7 +201,7 @@ describe("scan()", () => {
             errorLine1="        android:hint=&quot;Email Address&quot;"
             errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
             <location
-                file="feature/src/main/res/layout/fragment_password_reset.xml"
+                file="/root/feature/src/main/res/layout/fragment_password_reset.xml"
                 line="13"
                 column="9"/>
         </issue>
@@ -211,6 +213,7 @@ describe("scan()", () => {
       fileMask: "",
       reportSeverity: true,
       requireLineModification: true,
+      projectRoot: root,
     })
 
     expect(mockFileSync).toHaveBeenCalledTimes(123)

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,6 @@
 import { maxParallel, scan, scanXmlReport } from "."
 
-const root = "/root/"
+const root = "/root"
 const expectedAndroidLintViolation1: Violation = {
   issueId: "HardcodedText",
   category: "Internationalization",
@@ -38,7 +38,7 @@ const xmlReport = `
         errorLine1="        android:hint=&quot;Password&quot;"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="${expectedAndroidLintViolation1.file}"
+            file="/root/${expectedAndroidLintViolation1.file}"
             line="${expectedAndroidLintViolation1.line}"
             column="${expectedAndroidLintViolation1.column}"/>
     </issue>
@@ -54,7 +54,7 @@ const xmlReport = `
         errorLine1="        android:hint=&quot;Email Address&quot;"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="${expectedAndroidLintViolation2.file}"
+            file="/root/${expectedAndroidLintViolation2.file}"
             line="${expectedAndroidLintViolation2.line}"
             column="${expectedAndroidLintViolation2.column}"/>
     </issue>
@@ -87,7 +87,7 @@ const mockFileSync = jest.fn(
         errorLine1="        android:hint=&quot;Email Address&quot;"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="${expectedAndroidLintViolation1.file}"
+            file="/root/${expectedAndroidLintViolation1.file}"
             line="${expectedAndroidLintViolation1.line}"
             column="${expectedAndroidLintViolation1.column}"/>
     </issue>
@@ -139,10 +139,10 @@ describe("scan()", () => {
       return violation.message;
     })
     let violationFormatter: ViolationFormatter = {
-      format: formatFn, 
+      format: formatFn,
     }
 
-    
+
     const git = {
       modified_files: [expectedAndroidLintViolation1.file],
       created_files: [],
@@ -160,7 +160,7 @@ describe("scan()", () => {
       requireLineModification: true,
       violationFormatter: violationFormatter,
     })
-    
+
     expect(formatFn).toBeCalledWith(expectedAndroidLintViolation1)
     expect(global.warn).toBeCalledWith(formatFn(expectedAndroidLintViolation1), expectedAndroidLintViolation1.file, expectedAndroidLintViolation1.line)
   })
@@ -256,14 +256,14 @@ describe("scanXmlReport()", () => {
     }
     mockFileExistsSync.mockImplementation((path) =>
       [
-        "/otherRoot/" + expectedAndroidLintViolation1,
+        "/otherRoot/" + expectedAndroidLintViolation1.file,
         expectedAndroidLintViolation1.file.substring(expectedAndroidLintViolation1.file.indexOf("/", 1)),
       ].includes(path),
     )
 
     const violationCallback = jest.fn()
 
-    await scanXmlReport(git, xmlReport, "/otherRoot/", false, violationCallback)
+    await scanXmlReport(git, xmlReport, "/otherRoot", false, violationCallback)
 
     expect(violationCallback).toBeCalledWith(expectedAndroidLintViolation1)
   })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -38,7 +38,7 @@ const xmlReport = `
         errorLine1="        android:hint=&quot;Password&quot;"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="/root/${expectedAndroidLintViolation1.file}"
+            file="${root}/${expectedAndroidLintViolation1.file}"
             line="${expectedAndroidLintViolation1.line}"
             column="${expectedAndroidLintViolation1.column}"/>
     </issue>
@@ -54,7 +54,7 @@ const xmlReport = `
         errorLine1="        android:hint=&quot;Email Address&quot;"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="/root/${expectedAndroidLintViolation2.file}"
+            file="${root}/${expectedAndroidLintViolation2.file}"
             line="${expectedAndroidLintViolation2.line}"
             column="${expectedAndroidLintViolation2.column}"/>
     </issue>
@@ -64,8 +64,8 @@ const xmlReport = `
 const eslintXmlReport = `
 <?xml version="1.0" encoding="utf-8"?>
 <checkstyle version="4.3">
-  <file name="/root/src/components/ComponentNoError.tsx"></file>
-  <file name="/root/src/components/ComponentWithError.tsx">
+  <file name="${root}/src/components/ComponentNoError.tsx"></file>
+  <file name="${root}/src/components/ComponentWithError.tsx">
     <error line="2" column="21" severity="warning" message="&apos;CircularProgress&apos; is defined but never used. (@typescript-eslint/no-unused-vars)" source="eslint.rules.@typescript-eslint/no-unused-vars" />
   </file>
 </checkstyle>
@@ -87,7 +87,7 @@ const mockFileSync = jest.fn(
         errorLine1="        android:hint=&quot;Email Address&quot;"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="/root/${expectedAndroidLintViolation1.file}"
+            file="${root}/${expectedAndroidLintViolation1.file}"
             line="${expectedAndroidLintViolation1.line}"
             column="${expectedAndroidLintViolation1.column}"/>
     </issue>
@@ -201,7 +201,7 @@ describe("scan()", () => {
             errorLine1="        android:hint=&quot;Email Address&quot;"
             errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
             <location
-                file="/root/feature/src/main/res/layout/fragment_password_reset.xml"
+                file="${root}/feature/src/main/res/layout/fragment_password_reset.xml"
                 line="13"
                 column="9"/>
         </issue>

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export declare function markdown(message: string, file?: string, line?: number):
  */
 export async function scan(config: CheckstyleConfig) {
   const glob = require("glob")
-  const root = process.cwd()
+  const root = config.projectRoot ?? process.cwd()
   const git = danger.git
 
   const files: string[] = await new Promise((resolve, reject) =>
@@ -38,12 +38,12 @@ export async function scan(config: CheckstyleConfig) {
           if (!config.reportSeverity) {
             severity = "info"
           }
-          
+
           var msg = violationFormatter.format(violation)
           if (config.outputPrefix) {
             msg = config.outputPrefix + msg
           }
-          
+
           sendViolationBySeverity(msg, violation.file, violation.line, violation.severity)
         })
       }),


### PR DESCRIPTION
Currently a custom root path cannot be passed to `scan()` when using Danger JS image on CI, which are installed in different path than the project root path, such as `/opt/danger-js`.

This PR will allow to specify a custom root path (instead of current working directory).