### PR TITLE
feat(checkstyleconfig): adds a `removeDuplicates` option to remove duplicate violations

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ interface CheckstyleConfig {
    * Optional: Override the violation formatter to customize the output message.
    */
    violationFormatter?: ViolationFormatter
+
+  /**
+   * Optional: If set to true, it will remove duplicate violations.
+   */
+  removeDuplicates?: boolean
 }
 ```
 ## Changelog

--- a/src/checkstyleconfig.ts
+++ b/src/checkstyleconfig.ts
@@ -30,4 +30,9 @@ interface CheckstyleConfig {
    * Optional: Sets the root directory of the project. Defaults to the current working directory.
    */
   projectRoot?: string
+
+  /**
+   * Optional: If set to true, it will remove duplicate violations.
+   */
+  removeDuplicates?: boolean
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,6 @@ export async function scan(config: CheckstyleConfig) {
         const xmlReport = readFileSync(fileName)
 
         await scanXmlReport(git, xmlReport, root, config.requireLineModification, (violation: Violation) => {
-          var severity = violation.severity
           if (!config.reportSeverity) {
             violation.severity = "info"
           }
@@ -59,7 +58,7 @@ export async function scan(config: CheckstyleConfig) {
 }
 
 function generateMessageAndReport(violation: Violation, violationFormatter: ViolationFormatter, outputPrefix?: string) {
-  var msg = violationFormatter.format(violation)
+  let msg = violationFormatter.format(violation)
   if (outputPrefix) {
     msg = outputPrefix + msg
   }


### PR DESCRIPTION
This creates a new optional `removeDuplicates` option that will filter duplicate violations found while scanning and report them just once.

fix #2

This was specially noticeable in our repo with multi-module setup, where 2 violations ended up being reported as ~40 since they were in a base module imported transitively into almost every other one.

My knowledge of TS is quite limited, so the code might not be the best. I tried adding a new test case and it passes.